### PR TITLE
Small performance improvement in `l2_error` calculation

### DIFF
--- a/Metrics/metrics.py
+++ b/Metrics/metrics.py
@@ -110,7 +110,7 @@ def l2_error(confs, preds, labels, num_bins=15):
         bin_count = bin_dict[i][COUNT]
         l2_sum += (float(bin_count) / num_samples) * \
                (bin_accuracy - bin_confidence)**2
-        l2_error = math.sqrt(l2_sum)
+    l2_error = math.sqrt(l2_sum)
     return l2_error
 
 


### PR DESCRIPTION
When calculating the L2 error for ECE, the square root of the sum is taken repeatedly inside the loop. This result is unused in all but the last iteration so a minimal performance gain may be obtained by taking this calculation out of the loop and doing it only once before returning.